### PR TITLE
fix: only get required content for previews

### DIFF
--- a/src/database/queries/get_all.sql
+++ b/src/database/queries/get_all.sql
@@ -1,1 +1,3 @@
-SELECT * FROM clipboard ORDER BY last_updated DESC
+SELECT id, substr (content, 1, ?) AS content, last_updated
+FROM clipboard
+ORDER BY last_updated DESC


### PR DESCRIPTION
Only get a limited section of the `content` field for entries when previewing (based on the max preview width). This speeds up `clipvault list` significantly when there are large saved entries, e.g. image data.