### PR TITLE
fix: truncate text for previews on grapheme clusters, not unicode code points

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,6 +365,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -2104,6 +2105,12 @@ name = "unicode-linebreak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,7 @@ keywords = ["clipboard", "clipboard-history", "clipboard-manager"]
 categories = ["command-line-utilities"]
 
 [dependencies]
-miette = { version = "7.6", features = ["fancy"] }
-
+# CLI args
 clap = { version = "4.5", features = ["derive", "env"] }
 argfile = { version = "0.2" }
 dirs = { version = "6.0" }
@@ -35,6 +34,9 @@ tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-appender = { version = "0.2" }
 
+# Misc
+unicode-segmentation = "1.10"                      # Limit preview width by grapheme clusters
+miette = { version = "7.6", features = ["fancy"] } # Fancy errors
 
 [dev-dependencies]
 pretty_assertions = "1.4"


### PR DESCRIPTION
Should work better for other languages (and emojis etc.) now