### PR TITLE
fix: include newline at the end of `list` output

### DIFF
--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -110,7 +110,7 @@ pub fn execute(path_db: &Path, args: ListArgs) -> Result<()> {
         .join("\n");
 
     let mut stdout = stdout().lock();
-    ignore_broken_pipe(write!(&mut stdout, "{output}",))
+    ignore_broken_pipe(writeln!(&mut stdout, "{output}",))
         .into_diagnostic()
         .context("failed to write to STDOUT")?;
     ignore_broken_pipe(stdout.flush())


### PR DESCRIPTION
Just a quick fix - include a newline at the end of `list` output, which I believe is the standard (e.g. `cliphist`). Someone more knowledgeable than me can let me know if this should also be the case for, e.g. `get`, though appending a newline to the end of that output seems incorrect.