### PR TITLE
fix: limit number of log files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2041,8 +2041,7 @@ dependencies = [
 [[package]]
 name = "tracing"
 version = "0.1.41"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+source = "git+https://github.com/tokio-rs/tracing.git#ed3300c9f0e0ced79b721d35810daec9362d981a"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -2052,11 +2051,10 @@ dependencies = [
 [[package]]
 name = "tracing-appender"
 version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+source = "git+https://github.com/tokio-rs/tracing.git#ed3300c9f0e0ced79b721d35810daec9362d981a"
 dependencies = [
  "crossbeam-channel",
- "thiserror 1.0.69",
+ "thiserror 2.0.16",
  "time",
  "tracing-subscriber",
 ]
@@ -2064,8 +2062,7 @@ dependencies = [
 [[package]]
 name = "tracing-attributes"
 version = "0.1.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+source = "git+https://github.com/tokio-rs/tracing.git#ed3300c9f0e0ced79b721d35810daec9362d981a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2075,8 +2072,7 @@ dependencies = [
 [[package]]
 name = "tracing-core"
 version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+source = "git+https://github.com/tokio-rs/tracing.git#ed3300c9f0e0ced79b721d35810daec9362d981a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -2085,8 +2081,7 @@ dependencies = [
 [[package]]
 name = "tracing-log"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+source = "git+https://github.com/tokio-rs/tracing.git#ed3300c9f0e0ced79b721d35810daec9362d981a"
 dependencies = [
  "log",
  "once_cell",
@@ -2096,8 +2091,7 @@ dependencies = [
 [[package]]
 name = "tracing-subscriber"
 version = "0.3.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+source = "git+https://github.com/tokio-rs/tracing.git#ed3300c9f0e0ced79b721d35810daec9362d981a"
 dependencies = [
  "matchers",
  "nu-ansi-term",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,11 @@ rusqlite_migration = { version = "2.3", features = ["from-directory"] }
 include_dir = { version = "0.7" }
 
 # Logging
-tracing = { version = "0.1" }
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-tracing-appender = { version = "0.2" }
+tracing = { version = "0.1", git = "https://github.com/tokio-rs/tracing.git" }
+tracing-subscriber = { features = [
+  "env-filter",
+], git = "https://github.com/tokio-rs/tracing.git" }
+tracing-appender = { version = "0.2", git = "https://github.com/tokio-rs/tracing.git" }
 
 # Misc
 unicode-segmentation = "1.10"                      # Limit preview width by grapheme clusters

--- a/deny.toml
+++ b/deny.toml
@@ -6,8 +6,7 @@ no-default-features = false
 feature-depth = 1
 
 [advisories]
-# Ignore unmaintained crates for now - `paste` used by `ratatui` is unmaintained.
-# TODO: remove when `0.30` is released
+# `paste` crate used by `images`
 unmaintained = "none"
 
 [licenses]
@@ -36,8 +35,5 @@ external-default-features = "allow"
 [sources]
 unknown-registry = "deny"
 unknown-git = "deny"
-allow-registry = [
-  "https://github.com/rust-lang/crates.io-index",
-  "https://github.com/juhaku/utoipa",
-]
-allow-git = []
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = ["https://github.com/tokio-rs/tracing.git"]


### PR DESCRIPTION
Temporary workaround since the current release of `tracing-appender` does not work as intended. Hence, we use the `git` sources for the `tracing`-related crates, which include a fix.

See <https://github.com/tokio-rs/tracing/issues/3181> to track the issue, and <https://github.com/tokio-rs/tracing/issues/3282> to track the next release(s).