### PR TITLE
refactor: bump max number of log files to be stored to 7 (n+1)

### DIFF
--- a/src/logging.rs
+++ b/src/logging.rs
@@ -28,7 +28,7 @@ pub fn init_logging() -> Result<WorkerGuard> {
     let file_appender = tracing_appender::rolling::Builder::new()
         .rotation(Rotation::DAILY)
         .filename_suffix("log")
-        .max_log_files(2)
+        .max_log_files(8)
         .build(dir)
         .expect("failed to build log appender");
 


### PR DESCRIPTION
Current max limit of 2 will often only leave 1 file. From the tracing appender docs:

> The exact number of retained files can sometimes dip below the maximum, so if you need to retain `m` log files, specify a max of `m + 1`.

Thought I may as well also bump it to ~1 week of log files, just in case.