### PR TITLE
fix: various fixes and improvements to binary data previews

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,9 +46,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -61,15 +61,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -96,9 +96,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.101"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "approx"
@@ -153,9 +153,9 @@ dependencies = [
 
 [[package]]
 name = "assert_cmd"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c5bcfa8749ac45dd12cb11055aeeb6b27a3895560d60d71e3c23bf979e60514"
+checksum = "9a686bbee5efb88a82df0621b236e74d925f470e5445d3220a5648b892ec99c9"
 dependencies = [
  "anstyle",
  "bstr",
@@ -300,9 +300,9 @@ checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytemuck"
@@ -318,9 +318,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -342,9 +342,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
-version = "4.5.58"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63be97961acde393029492ce0be7a1af7e323e6bae9511ebfac33751be5e6806"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -352,9 +352,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.58"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f13174bda5dfd69d7e947827e5af4b0f2f94a4a3ee92912fba07a66150f21e2"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -365,9 +365,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -377,9 +377,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clipvault"
@@ -413,9 +413,9 @@ dependencies = [
 
 [[package]]
 name = "codspeed"
-version = "4.3.0"
+version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c2eb3388ebe26b5a0ab6bf4969d9c4840143d7f6df07caa3cc851b0606cef6"
+checksum = "b684e94583e85a5ca7e1a6454a89d76a5121240f2fb67eb564129d9bafdb9db0"
 dependencies = [
  "anyhow",
  "cc",
@@ -431,9 +431,9 @@ dependencies = [
 
 [[package]]
 name = "codspeed-divan-compat"
-version = "4.3.0"
+version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2de65b7489a59709724d489070c6d05b7744039e4bf751d0a2006b90bb5593d"
+checksum = "89e4bf8c7793c170fd0fcf3be97b9032b2ae39c2b9e8818aba3cc10ca0f0c6c0"
 dependencies = [
  "clap",
  "codspeed",
@@ -444,9 +444,9 @@ dependencies = [
 
 [[package]]
 name = "codspeed-divan-compat-macros"
-version = "4.3.0"
+version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56ca01ce4fd22b8dcc6c770dcd6b74343642e842482b94e8920d14e10c57638d"
+checksum = "78aae02f2a278588e16e8ca62ea1915b8ab30f8230a09926671bba19ede801a4"
 dependencies = [
  "divan-macros",
  "itertools",
@@ -458,9 +458,9 @@ dependencies = [
 
 [[package]]
 name = "codspeed-divan-compat-walltime"
-version = "4.3.0"
+version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "720ab9d0714718afe5f5832be6e5f5eb5ce97836e24ca7bf7042eea4308b9fb8"
+checksum = "59ffd32c0c59ab8b674b15be65ba7c59aebac047036cfa7fa1e11bc2c178b81f"
 dependencies = [
  "cfg-if",
  "clap",
@@ -479,9 +479,9 @@ checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "colored"
@@ -580,9 +580,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "deranged"
-version = "0.5.6"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
 ]
@@ -832,19 +832,19 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -1031,9 +1031,9 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.25.9"
+version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
@@ -1049,8 +1049,8 @@ dependencies = [
  "rayon",
  "rgb",
  "tiff",
- "zune-core 0.5.1",
- "zune-jpeg 0.5.12",
+ "zune-core",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -1162,9 +1162,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1190,9 +1190,9 @@ checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -1206,11 +1206,10 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
- "bitflags",
  "libc",
 ]
 
@@ -1227,9 +1226,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1335,9 +1334,9 @@ dependencies = [
 
 [[package]]
 name = "moxcms"
-version = "0.7.11"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
 dependencies = [
  "num-traits",
  "pxfm",
@@ -1351,9 +1350,9 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
-version = "0.30.1"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1458,9 +1457,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -1485,9 +1484,9 @@ dependencies = [
 
 [[package]]
 name = "owo-colors"
-version = "4.2.3"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "paste"
@@ -1509,9 +1508,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
@@ -1608,9 +1607,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit",
 ]
@@ -1664,12 +1663,9 @@ dependencies = [
 
 [[package]]
 name = "pxfm"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7186d3822593aa4393561d186d1393b3923e9d6163d3fbfd6e825e3e6cf3e6a8"
-dependencies = [
- "num-traits",
-]
+checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
 
 [[package]]
 name = "qoi"
@@ -1694,9 +1690,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -1706,6 +1702,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -1782,9 +1784,9 @@ dependencies = [
 
 [[package]]
 name = "ravif"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef69c1990ceef18a116855938e74793a5f7496ee907562bd0857b6ac734ab285"
+checksum = "e52310197d971b0f5be7fe6b57530dcd27beb35c1b013f29d66c1ad73fbbcc45"
 dependencies = [
  "avif-serialize",
  "imgref",
@@ -1857,15 +1859,15 @@ checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rgb"
-version = "0.8.52"
+version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 
 [[package]]
 name = "rsqlite-vfs"
@@ -1911,9 +1913,9 @@ checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
@@ -2088,9 +2090,9 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
-version = "2.0.116"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df424c70518695237746f84cede799c9c58fcb37450d7b23716568cc8bc69cb"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2110,12 +2112,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.25.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2178,16 +2180,16 @@ dependencies = [
 
 [[package]]
 name = "tiff"
-version = "0.10.3"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af9605de7fee8d9551863fd692cce7637f548dbd9db9180fcc07ccc6d26c336f"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
 dependencies = [
  "fax",
  "flate2",
  "half",
  "quick-error 2.0.1",
  "weezl",
- "zune-jpeg 0.4.21",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -2233,18 +2235,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
+version = "1.0.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.23.10+spec-1.0.0"
+version = "0.25.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -2318,9 +2320,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -2458,9 +2460,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2471,9 +2473,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2481,9 +2483,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2494,9 +2496,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
@@ -2705,9 +2707,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
@@ -2843,18 +2845,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.39"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.39"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2923,12 +2925,6 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zune-core"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
-
-[[package]]
-name = "zune-core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
@@ -2944,18 +2940,9 @@ dependencies = [
 
 [[package]]
 name = "zune-jpeg"
-version = "0.4.21"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
+checksum = "ec5f41c76397b7da451efd19915684f727d7e1d516384ca6bd0ec43ec94de23c"
 dependencies = [
- "zune-core 0.4.12",
-]
-
-[[package]]
-name = "zune-jpeg"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "410e9ecef634c709e3831c2cfdb8d9c32164fae1c67496d5b68fff728eec37fe"
-dependencies = [
- "zune-core 0.5.1",
+ "zune-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,11 @@ proptest = "1.9"
 insta = "1.46"
 divan = { version = "4.1.0", package = "codspeed-divan-compat" }
 
+[features]
+default = []
+# Enable memory benchmarks
+bench_mem = []
+
 [[bench]]
 name = "base"
 harness = false

--- a/benches/base.rs
+++ b/benches/base.rs
@@ -1,12 +1,10 @@
-use std::io::Cursor;
-use std::sync::LazyLock;
+use std::{io::Cursor, sync::LazyLock};
 
-use clipvault::cli::{GetDelArgs, ListArgs, StoreArgs};
-use clipvault::commands::{get, list, store};
-use clipvault::defaults;
+use clipvault::{cli::{GetDelArgs, ListArgs, StoreArgs}, commands::{get, list, store}, defaults};
+#[cfg(feature = "bench_mem")]
 use divan::AllocProfiler;
 use tempfile::NamedTempFile;
-
+#[cfg(feature = "bench_mem")]
 #[global_allocator]
 static ALLOC: AllocProfiler = AllocProfiler::system();
 

--- a/justfile
+++ b/justfile
@@ -2,6 +2,8 @@ alias c := check
 alias f := format
 alias t := test
 alias b := build
+alias bn := bench
+alias bm := bench-mem
 alias d := develop
 alias r := run
 alias rr := run-release
@@ -46,3 +48,11 @@ run-release *FLAGS:
 # Publish the crate
 publish: test
     cargo publish
+
+# Benchmarks
+bench *ARGS:
+    cargo bench {{ ARGS }}
+
+# Benchmarks with memory stats
+bench-mem *ARGS:
+    cargo bench --features="bench_mem" {{ ARGS }}

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,8 @@
+group_imports = "StdExternalCrate"
+imports_granularity = "Crate"
+imports_indent = "Visual"
+imports_layout = "Horizontal"
+newline_style = "Unix"
+reorder_modules = true
+style_edition = "2024"
+wrap_comments = true

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -52,7 +52,8 @@ pub struct StoreArgs {
     #[arg(long, default_value_t = defaults::MAX_ENTRIES, env = "CLIPVAULT_MAX_ENTRIES")]
     pub max_entries: usize,
 
-    /// Entries older than this value will be deleted. Only accurate to the second.
+    /// Entries older than this value will be deleted. Only accurate to the
+    /// second.
     ///
     /// Setting this value to 0s or less disables the limit.
     #[arg(long, default_value = defaults::MAX_ENTRY_AGE, env = "CLIPVAULT_MAX_AGE")]
@@ -70,19 +71,24 @@ pub struct StoreArgs {
     #[arg(long, default_value_t = defaults::MIN_ENTRY_LEN, env = "CLIPVAULT_MIN_LENGTH")]
     pub min_entry_length: usize,
 
-    /// Store sensitive values, ignoring e.g. CLIPBOARD_STATE="sensitive" set by wl-clipboard.
+    /// Store sensitive values, ignoring e.g. CLIPBOARD_STATE="sensitive" set by
+    /// wl-clipboard.
     #[arg(long, action, env = "CLIPVAULT_STORE_SENSITIVE")]
     pub store_sensitive: bool,
 
-    /// Entries which include any match for the given regex pattern will not be stored.
+    /// Entries which include any match for the given regex pattern will not be
+    /// stored.
     ///
-    /// To specify multiple patterns, simply call the argument again with a new pattern. Be mindful
-    /// of the fact that every regex pattern given will be tested against every text input.
+    /// To specify multiple patterns, simply call the argument again with a new
+    /// pattern. Be mindful of the fact that every regex pattern given will
+    /// be tested against every text input.
     ///
-    /// e.g. clipvault --store --ignore-pattern '^<meta http-equiv=' --ignore-pattern 'ignore\n$'
+    /// e.g. clipvault --store --ignore-pattern '^<meta http-equiv='
+    /// --ignore-pattern 'ignore\n$'
     ///
-    /// Note that look-around and backreferences are not supported, as the Rust implementation
-    /// of a regex engine used does not support those features.
+    /// Note that look-around and backreferences are not supported, as the Rust
+    /// implementation of a regex engine used does not support those
+    /// features.
     #[arg(long, action, env = "CLIPVAULT_IGNORE_PATTERN", num_args = 1)]
     pub ignore_pattern: Option<Vec<Regex>>,
 }
@@ -137,8 +143,8 @@ pub struct GetDelArgs {
     pub input: String,
     /// The relative index of the desired entry (starting at 0). Negative
     /// values are interpreted as starting from the oldest entries first.
-    /// For example, 0 represents the newest entry, 1 the entry just before that,
-    /// and -1 represents the oldest entry.
+    /// For example, 0 represents the newest entry, 1 the entry just before
+    /// that, and -1 represents the oldest entry.
     ///
     /// *NOTE*: conflicts with positional input, and will ignore
     /// STDIN in the case where input is not provided.

--- a/src/commands/delete.rs
+++ b/src/commands/delete.rs
@@ -1,18 +1,9 @@
-use std::{
-    io::{Read, stdin},
-    path::Path,
-};
+use std::{io::{Read, stdin}, path::Path};
 
 use miette::{Context, IntoDiagnostic, Result, miette};
 
 use super::{extract_id, wrap_index};
-use crate::{
-    cli::GetDelArgs,
-    database::{
-        init_db,
-        queries::{count_entries, delete_entry_by_id, delete_entry_by_position},
-    },
-};
+use crate::{cli::GetDelArgs, database::{init_db, queries::{count_entries, delete_entry_by_id, delete_entry_by_position}}};
 
 #[tracing::instrument(skip(path_db))]
 pub fn execute(path_db: &Path, args: GetDelArgs) -> Result<()> {

--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -1,21 +1,9 @@
-use std::{
-    io::{Read, Write, stdin, stdout},
-    path::Path,
-};
+use std::{io::{Read, Write, stdin, stdout}, path::Path};
 
 use miette::{Context, IntoDiagnostic, Result, miette};
 
 use super::extract_id;
-use crate::{
-    cli::GetDelArgs,
-    commands::wrap_index,
-    database::{
-        data::ClipboardEntry,
-        init_db,
-        queries::{count_entries, get_entry_by_id, get_entry_by_position},
-    },
-    utils::ignore_broken_pipe,
-};
+use crate::{cli::GetDelArgs, commands::wrap_index, database::{data::ClipboardEntry, init_db, queries::{count_entries, get_entry_by_id, get_entry_by_position}}, utils::ignore_broken_pipe};
 
 fn get_entry(path_db: &Path, mut input: String) -> Result<ClipboardEntry> {
     // Read from STDIN if no argument given

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -1,39 +1,16 @@
-use std::{
-    io::{BufWriter, Cursor, Write, stdout},
-    path::Path,
-};
+use std::{io::{BufWriter, Write, stdout}, path::Path};
 
 use content_inspector::ContentType;
-use image::{DynamicImage, GenericImageView, ImageReader};
+use image::GenericImageView;
 use miette::{Context, IntoDiagnostic, Result};
-use mime_sniffer::MimeTypeSniffer;
 
 use super::SEPARATOR;
+use crate::{cli::ListArgs, database::{data::ClipboardEntry, init_db, queries::get_all_entries}, utils::{decode_image, get_mimetype, human_bytes, ignore_broken_pipe, truncate}};
 
-use crate::{
-    cli::ListArgs,
-    database::{init_db, queries::get_all_entries},
-    utils::{human_bytes, ignore_broken_pipe, truncate},
-};
-
-fn decode_image(data: &[u8]) -> Option<(&'static str, DynamicImage)> {
-    let img_reader = ImageReader::new(Cursor::new(data))
-        .with_guessed_format()
-        .ok()?;
-    let mimetype = img_reader.format()?.to_mime_type();
-    let img = img_reader.decode().ok()?;
-
-    Some((mimetype, img))
-}
-
-fn get_mimetype(data: &[u8]) -> Option<String> {
-    data.sniff_mime_type().map(String::from)
-}
-
-#[tracing::instrument(skip(data))]
-fn preview_text(data: &[u8], width: usize) -> String {
-    let mut result = String::with_capacity(data.len());
-    String::from_utf8_lossy(data)
+#[tracing::instrument()]
+fn preview_text(entry: &ClipboardEntry) -> String {
+    let mut result = String::with_capacity(entry.content.len());
+    String::from_utf8_lossy(&entry.content)
         .split_whitespace()
         .for_each(|w| {
             if !result.is_empty() {
@@ -42,44 +19,59 @@ fn preview_text(data: &[u8], width: usize) -> String {
             result.push_str(w);
         });
 
-    truncate(&result, width).into_owned()
+    result
 }
 
-#[tracing::instrument(skip(data))]
-fn preview_binary(data: &[u8], width: usize) -> String {
-    // Early return if data won't be visible in preview anyway
-    if width < "[[ binary data ".len() {
-        return truncate("[[ binary data ", width).into_owned();
-    };
-
+#[tracing::instrument()]
+fn preview_binary(entry: &ClipboardEntry) -> String {
     // Human readable representation of the byte count of the binary data
-    let byte_count = human_bytes(data.len());
+    let byte_count = human_bytes(entry.content_size);
 
-    // More details for image types
-    let result = if let Some((mimetype, img)) = decode_image(data) {
-        let (w, h) = img.dimensions();
-        format!("[[ binary data {byte_count} {mimetype} {w}x{h} ]]")
-    }
-    // Try and parse mime-type for other binary data
-    else if let Some(mimetype) = get_mimetype(data) {
-        format!("[[ binary data {byte_count} {mimetype} ]]")
-    } else {
-        format!("[[ binary data {byte_count} ]]")
+    let Some(mimetype) = entry.mimetype.as_ref() else {
+        return format!("[[ binary data {byte_count} ]]");
     };
 
-    truncate(&result, width).into_owned()
+    if let Some(extra_preview_data) = entry.extra_preview_data.as_ref() {
+        format!("[[ binary data {byte_count} {mimetype} {extra_preview_data} ]]")
+    } else {
+        format!("[[ binary data {byte_count} {mimetype} ]]")
+    }
 }
 
-#[tracing::instrument(skip(data))]
-fn preview(id: u64, data: &[u8], width: usize) -> String {
-    let data_type = content_inspector::inspect(data);
-    let s = match data_type {
-        ContentType::BINARY => preview_binary(data, width),
-        ContentType::UTF_8 | ContentType::UTF_8_BOM => preview_text(data, width),
-        _ => "[[ Non-UTF-8 text ]]".into(),
-    };
+#[tracing::instrument()]
+fn preview(mut entry: ClipboardEntry, width: usize) -> String {
+    // Fallback for entries created with clipvault v1.1.1 and older, which would not
+    // have some of the additional preview data stored in the DB
+    let content_type = entry.content_type.unwrap_or_else(|| {
+        let content_type = content_inspector::inspect(&entry.content);
+        entry.content_type = Some(content_type);
 
-    format!("{id}{SEPARATOR}{s}")
+        if content_type.is_binary() {
+            if let Some((img_mimetype, img)) = decode_image(&entry.content) {
+                let (w, h) = img.dimensions();
+                entry.extra_preview_data = Some(format!("{w}x{h}"));
+                entry.mimetype = Some(img_mimetype.into());
+            } else if let Some(content_mimetype) = get_mimetype(&entry.content) {
+                entry.mimetype = Some(content_mimetype);
+            }
+        }
+
+        content_type
+    });
+
+    let s = match content_type {
+        ContentType::BINARY => preview_binary(&entry),
+        ContentType::UTF_8 => preview_text(&entry),
+        ContentType::UTF_8_BOM => {
+            // Remove BOM so remaining data can be parsed as regular UTF-8
+            entry.content.drain(..3);
+            preview_text(&entry)
+        }
+        _ => String::from("[[ Non-UTF-8 text ]]"),
+    };
+    let truncated = truncate(s, width);
+
+    format!("{}{SEPARATOR}{truncated}", entry.id)
 }
 
 #[tracing::instrument(skip(path_db))]
@@ -120,7 +112,7 @@ fn execute_inner(path_db: &Path, args: ListArgs, show_output: bool) -> Result<()
 
     for entry in entries
         .into_iter()
-        .map(|entry| preview(entry.id, &entry.content, preview_width))
+        .map(|entry| preview(entry, preview_width))
     {
         if show_output {
             writer

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use content_inspector::ContentType;
-use image::{GenericImageView, ImageReader};
+use image::{DynamicImage, GenericImageView, ImageReader};
 use miette::{Context, IntoDiagnostic, Result};
 use mime_sniffer::MimeTypeSniffer;
 
@@ -16,25 +16,21 @@ use crate::{
     utils::{human_bytes, ignore_broken_pipe, truncate},
 };
 
-fn preview_image(data: &[u8]) -> Option<String> {
+fn decode_image(data: &[u8]) -> Option<(&'static str, DynamicImage)> {
     let img_reader = ImageReader::new(Cursor::new(data))
         .with_guessed_format()
         .ok()?;
-    let format = img_reader.format()?;
+    let mimetype = img_reader.format()?.to_mime_type();
     let img = img_reader.decode().ok()?;
-    let (width, height) = img.dimensions();
 
-    Some(format!(
-        "[[ binary data {} {} {width}x{height} ]]",
-        human_bytes(data.len()),
-        format.to_mime_type(),
-    ))
+    Some((mimetype, img))
 }
 
-fn get_mimemtype(data: &[u8]) -> Option<String> {
+fn get_mimetype(data: &[u8]) -> Option<String> {
     data.sniff_mime_type().map(String::from)
 }
 
+#[tracing::instrument(skip(data))]
 fn preview_text(data: &[u8], width: usize) -> String {
     let mut result = String::with_capacity(data.len());
     String::from_utf8_lossy(data)
@@ -50,21 +46,35 @@ fn preview_text(data: &[u8], width: usize) -> String {
 }
 
 #[tracing::instrument(skip(data))]
+fn preview_binary(data: &[u8], width: usize) -> String {
+    // Early return if data won't be visible in preview anyway
+    if width < "[[ binary data ".len() {
+        return truncate("[[ binary data ", width).into_owned();
+    };
+
+    // Human readable representation of the byte count of the binary data
+    let byte_count = human_bytes(data.len());
+
+    // More details for image types
+    let result = if let Some((mimetype, img)) = decode_image(data) {
+        let (w, h) = img.dimensions();
+        format!("[[ binary data {byte_count} {mimetype} {w}x{h} ]]")
+    }
+    // Try and parse mime-type for other binary data
+    else if let Some(mimetype) = get_mimetype(data) {
+        format!("[[ binary data {byte_count} {mimetype} ]]")
+    } else {
+        format!("[[ binary data {byte_count} ]]")
+    };
+
+    truncate(&result, width).into_owned()
+}
+
+#[tracing::instrument(skip(data))]
 fn preview(id: u64, data: &[u8], width: usize) -> String {
     let data_type = content_inspector::inspect(data);
     let s = match data_type {
-        ContentType::BINARY => {
-            // More details for image types
-            if let Some(img_msg) = preview_image(data) {
-                img_msg
-            }
-            // Try and parse mime-type for other binary data
-            else if let Some(mimetype) = get_mimemtype(data) {
-                format!("[[ binary data {mimetype} ]]")
-            } else {
-                "[[ binary data ]]".into()
-            }
-        }
+        ContentType::BINARY => preview_binary(data, width),
         ContentType::UTF_8 | ContentType::UTF_8_BOM => preview_text(data, width),
         _ => "[[ Non-UTF-8 text ]]".into(),
     };

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -60,7 +60,7 @@ fn preview(id: u64, data: &[u8], width: usize) -> String {
             }
             // Try and parse mime-type for other binary data
             else if let Some(mimetype) = get_mimemtype(data) {
-                format!("[[ binary data {mimetype}]]")
+                format!("[[ binary data {mimetype} ]]")
             } else {
                 "[[ binary data ]]".into()
             }

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -1,4 +1,4 @@
-use std::{io::{BufWriter, Write, stdout}, path::Path};
+use std::{borrow::Cow, io::{BufWriter, Write, stdout}, num::NonZero, path::Path, sync::{Arc, atomic::{AtomicUsize, Ordering}, mpsc::sync_channel}, thread};
 
 use content_inspector::ContentType;
 use image::GenericImageView;
@@ -32,10 +32,14 @@ fn preview_binary(entry: &ClipboardEntry) -> String {
 }
 
 #[tracing::instrument()]
-fn preview(mut entry: ClipboardEntry, width: usize) -> String {
+fn preview(entry: &ClipboardEntry, width: usize) -> String {
+    let mut entry = Cow::Borrowed(entry);
+
     // Fallback for entries created with clipvault v1.1.1 and older, which would not
     // have some of the additional preview data stored in the DB
     let content_type = entry.content_type.unwrap_or_else(|| {
+        let entry = entry.to_mut();
+
         let content_type = content_inspector::inspect(&entry.content);
         entry.content_type = Some(content_type);
 
@@ -52,17 +56,19 @@ fn preview(mut entry: ClipboardEntry, width: usize) -> String {
         content_type
     });
 
-    let s = match content_type {
-        ContentType::BINARY => preview_binary(&entry),
-        ContentType::UTF_8 => preview_text(&entry),
-        ContentType::UTF_8_BOM => {
-            // Remove BOM so remaining data can be parsed as regular UTF-8
-            entry.content.drain(..3);
-            preview_text(&entry)
-        }
-        _ => String::from("[[ Non-UTF-8 text ]]"),
-    };
-    let truncated = truncate(s, width);
+    let truncated = truncate(
+        match content_type {
+            ContentType::BINARY => preview_binary(entry.as_ref()),
+            ContentType::UTF_8 => preview_text(entry.as_ref()),
+            ContentType::UTF_8_BOM => {
+                // Remove BOM so remaining data can be parsed as regular UTF-8
+                entry.to_mut().content.drain(..3);
+                preview_text(&entry)
+            }
+            _ => String::from("[[ Non-UTF-8 text ]]"),
+        },
+        width,
+    );
 
     format!("{}{SEPARATOR}{truncated}", entry.id)
 }
@@ -97,33 +103,61 @@ fn execute_inner(path_db: &Path, args: ListArgs, show_output: bool) -> Result<()
         return Ok(());
     }
 
+    // Use multiple threads to generate entry previews
+    let previews = thread::scope(move |s| {
+        let len = entries.len();
+        let (tx, rx) = sync_channel(len);
+        let data = Arc::new((AtomicUsize::new(0), entries));
+
+        let num_threads: usize = thread::available_parallelism()
+            .unwrap_or(NonZero::new(1).unwrap())
+            .into();
+
+        for _ in 0..num_threads {
+            let tx = tx.clone();
+            let data = Arc::clone(&data);
+            s.spawn(move || {
+                let (index, entries) = data.as_ref();
+                while let i = index.fetch_add(1, Ordering::Relaxed)
+                    && i < entries.len()
+                {
+                    tx.send((i, preview(&entries[i], preview_width).into_bytes()))
+                        .expect("channel shouldn't be closed");
+                }
+            });
+        }
+        drop(tx);
+
+        let mut output = vec![vec![]; len];
+        while let Ok((i, s)) = rx.recv() {
+            output[i] = s;
+        }
+        output
+    });
+
+    // Write previews to STDOUT
     let stdout = stdout();
     let stdout = stdout.lock();
+    let mut writer = BufWriter::with_capacity(12 * 1024, stdout);
 
-    // [`BufWriter`] for more efficient, buffered writes
-    let mut writer = BufWriter::with_capacity(8 * 1024, stdout);
+    for mut entry in previews {
+        entry.push(b'\n');
+        let entry = entry.as_slice();
 
-    for entry in entries
-        .into_iter()
-        .map(|entry| preview(entry, preview_width))
-    {
-        if show_output {
-            writer
-                .write(&entry.into_bytes())
-                .into_diagnostic()
-                .context("failed to write to STDOUT")?;
-            writer
-                .write(b"\n")
-                .into_diagnostic()
-                .context("failed to write to STDOUT")?;
+        if !show_output {
+            continue;
         }
+
+        writer
+            .write(entry)
+            .into_diagnostic()
+            .context("failed to write to STDOUT")?;
     }
 
+    // Flush all remaining output in the buffered writer
     ignore_broken_pipe(writer.flush())
         .into_diagnostic()
-        .context("failed to flush STDOUT")?;
-
-    Ok(())
+        .context("failed to flush STDOUT")
 }
 
 #[tracing::instrument(skip(path_db))]

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -9,17 +9,10 @@ use crate::{cli::ListArgs, database::{data::ClipboardEntry, init_db, queries::ge
 
 #[tracing::instrument()]
 fn preview_text(entry: &ClipboardEntry) -> String {
-    let mut result = String::with_capacity(entry.content.len());
     String::from_utf8_lossy(&entry.content)
         .split_whitespace()
-        .for_each(|w| {
-            if !result.is_empty() {
-                result.push(' ');
-            }
-            result.push_str(w);
-        });
-
-    result
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 #[tracing::instrument()]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -33,9 +33,10 @@ pub(super) fn wrap_index(len: usize, index: isize) -> usize {
 
 #[cfg(test)]
 mod test {
-    use super::*;
     use pretty_assertions::assert_eq;
     use proptest::prelude::*;
+
+    use super::*;
 
     #[test]
     fn test_extract_id() {

--- a/src/commands/store.rs
+++ b/src/commands/store.rs
@@ -1,20 +1,11 @@
-use std::{
-    io::{Read, stdin},
-    path::Path,
-};
+use std::{io::{Read, stdin}, path::Path};
 
 use content_inspector::ContentType;
+use image::GenericImageView;
 use miette::{Context, IntoDiagnostic, Result, miette};
 use tracing::instrument;
 
-use crate::{
-    cli::StoreArgs,
-    database::{
-        init_db,
-        queries::{delete_all_entries, delete_entries_older_than, trim_entries, upsert_entry},
-    },
-    utils::now,
-};
+use crate::{cli::StoreArgs, database::{data::ClipboardEntry, init_db, queries::{delete_all_entries, delete_entries_older_than, trim_entries, upsert_entry}}, utils::{decode_image, get_mimetype, now}};
 
 #[instrument]
 pub fn execute(path_db: &Path, args: StoreArgs) -> Result<()> {
@@ -120,8 +111,37 @@ pub fn execute_with_source(path_db: &Path, args: StoreArgs, mut source: impl Rea
         delete_entries_older_than(conn, timestamp)?;
     }
 
+    // Setup additional data to be stored for the entry
+    let entry = {
+        // Inspect the content type
+        let content_type = content_inspector::inspect(&buf);
+
+        // Additional data for images and other binary data
+        let (mut mimetype, mut extra_preview_data) = (None, None);
+        if content_type.is_binary() {
+            // Resolution and mimetype for images
+            if let Some((img_mimetype, img)) = decode_image(&buf) {
+                let (w, h) = img.dimensions();
+                extra_preview_data = Some(format!("{w}x{h}"));
+                mimetype = Some(img_mimetype.into());
+            }
+            // Only mimetype for other binary data (if detected)
+            else if let Some(content_mimetype) = get_mimetype(&buf) {
+                mimetype = Some(content_mimetype);
+            }
+        };
+
+        ClipboardEntry {
+            content: buf,
+            content_type: Some(content_type),
+            mimetype,
+            extra_preview_data,
+            ..Default::default()
+        }
+    };
+
     // Upsert new entry
-    upsert_entry(conn, &buf)?;
+    upsert_entry(conn, entry)?;
 
     // Trim entries if over limit
     if max_entries != 0 {

--- a/src/commands/store.rs
+++ b/src/commands/store.rs
@@ -2,7 +2,7 @@ use std::{io::{Read, stdin}, path::Path};
 
 use content_inspector::ContentType;
 use image::GenericImageView;
-use miette::{Context, IntoDiagnostic, Result, miette};
+use miette::{Context, IntoDiagnostic, Result, bail};
 use tracing::instrument;
 
 use crate::{cli::StoreArgs, database::{data::ClipboardEntry, init_db, queries::{delete_all_entries, delete_entries_older_than, trim_entries, upsert_entry}}, utils::{decode_image, get_mimetype, now}};
@@ -26,9 +26,7 @@ pub fn execute_with_source(path_db: &Path, args: StoreArgs, mut source: impl Rea
 
     // Min conflicts with max
     if min_bytes > max_bytes {
-        return Err(miette!(
-            "minimum entry length ({min_bytes}) exceeds maximum entry length ({max_bytes})"
-        ));
+        bail!("minimum entry length ({min_bytes}) exceeds maximum entry length ({max_bytes})")
     }
 
     // Set by `wl-clipboard`
@@ -63,14 +61,14 @@ pub fn execute_with_source(path_db: &Path, args: StoreArgs, mut source: impl Rea
             .context("failed to read from STDIN")?;
         buf
     };
+    drop(source);
 
-    // No content to store
     if buf.is_empty() {
         tracing::trace!("no content to store");
         return Ok(());
     }
 
-    // Ignore content larger than the max size or smaller than the min size in bytes
+    // Ignore content outside of the min and max byte constraints
     let gt_max = buf.len() > max_bytes && max_bytes != 0;
     let lt_min = buf.len() < min_bytes;
     if gt_max || lt_min {
@@ -116,7 +114,7 @@ pub fn execute_with_source(path_db: &Path, args: StoreArgs, mut source: impl Rea
         // Inspect the content type
         let content_type = content_inspector::inspect(&buf);
 
-        // Additional data for images and other binary data
+        // Store extra information for images and other binary data
         let (mut mimetype, mut extra_preview_data) = (None, None);
         if content_type.is_binary() {
             // Resolution and mimetype for images

--- a/src/database/data.rs
+++ b/src/database/data.rs
@@ -1,10 +1,18 @@
+use content_inspector::ContentType;
 use rusqlite::Row;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default)]
 pub struct ClipboardEntry {
     pub id: u64,
     pub content: Vec<u8>,
+    /// Size of the full content of the clipboard entry (in bytes).
+    /// NOTE: different to `self.content.len()` as that content may be
+    /// truncated.
+    pub content_size: usize,
     pub last_updated: u64,
+    pub mimetype: Option<String>,
+    pub extra_preview_data: Option<String>,
+    pub content_type: Option<ContentType>,
 }
 
 impl<'stmt> TryFrom<&Row<'stmt>> for ClipboardEntry {
@@ -12,11 +20,40 @@ impl<'stmt> TryFrom<&Row<'stmt>> for ClipboardEntry {
     fn try_from(row: &Row) -> std::result::Result<Self, Self::Error> {
         Ok(Self {
             id: row.get(0)?,
-            content: row.get(1)?,
-            last_updated: row.get(2)?,
+            content: row.get("content")?,
+            last_updated: row.get("last_updated")?,
+            mimetype: row.get("mimetype")?,
+            extra_preview_data: row.get("extra_preview_data")?,
+            content_size: row.get("content_size").unwrap_or_default(),
+            content_type: {
+                row
+                    // Stored entries from previous versions may not have this field defined
+                    .get::<&str, Option<u8>>("content_type")?
+                    .map(|n| {
+                        // TODO: remove once `content_inspector` has `from` implemented
+                        match n {
+                            1 => ContentType::UTF_8,
+                            2 => ContentType::UTF_8_BOM,
+                            3 => ContentType::UTF_16LE,
+                            4 => ContentType::UTF_16BE,
+                            5 => ContentType::UTF_32LE,
+                            6 => ContentType::UTF_32BE,
+                            _ => ContentType::BINARY,
+                        }
+                    })
+            },
         })
     }
 }
+
+impl PartialEq for ClipboardEntry {
+    fn eq(&self, other: &Self) -> bool {
+        self.content_size == other.content_size
+            && self.content_type == other.content_type
+            && self.content == other.content
+    }
+}
+impl Eq for ClipboardEntry {}
 
 impl Ord for ClipboardEntry {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
@@ -27,5 +64,11 @@ impl Ord for ClipboardEntry {
 impl PartialOrd for ClipboardEntry {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
+    }
+}
+
+impl AsRef<ClipboardEntry> for ClipboardEntry {
+    fn as_ref(&self) -> &ClipboardEntry {
+        self
     }
 }

--- a/src/database/migrations/03-preview-data/down.sql
+++ b/src/database/migrations/03-preview-data/down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE clipboard DROP COLUMN content_type;
+ALTER TABLE clipboard DROP COLUMN mimetype;
+ALTER TABLE clipboard DROP COLUMN extra_preview_data;

--- a/src/database/migrations/03-preview-data/up.sql
+++ b/src/database/migrations/03-preview-data/up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE clipboard ADD COLUMN content_type INTEGER;
+ALTER TABLE clipboard ADD COLUMN mimetype TEXT;
+ALTER TABLE clipboard ADD COLUMN extra_preview_data TEXT;

--- a/src/database/queries/get_all.sql
+++ b/src/database/queries/get_all.sql
@@ -1,3 +1,10 @@
-SELECT id, substr (content, 1, ?) AS content, last_updated
+SELECT
+    id,
+    last_updated,
+    substr (content, 1, ?) AS content,
+    octet_length (content) AS content_size,
+    content_type,
+    mimetype,
+    extra_preview_data
 FROM clipboard
 ORDER BY last_updated DESC

--- a/src/database/queries/mod.rs
+++ b/src/database/queries/mod.rs
@@ -18,17 +18,13 @@ pub fn count_entries(conn: &Connection) -> Result<usize> {
 pub fn get_all_entries(conn: &Connection, preview_width: usize) -> Result<Vec<ClipboardEntry>> {
     tracing::debug!("getting all entries");
 
-    // NOTE: query truncates the blob content based on the allowed preview width (with a minimum
-    // for ensuring file signatures are present)
-    let max_blob_width = (preview_width.saturating_add(preview_width)).max(50);
-
     let mut stmt = conn
         .prepare(include_str!("./get_all.sql"))
         .into_diagnostic()
         .context("failed to prepare: get all entries")?;
 
     let entries: Vec<ClipboardEntry> = stmt
-        .query(params![max_blob_width])
+        .query(params![preview_width])
         .into_diagnostic()
         .context("failed to query: get all entries")?
         .map(|c| ClipboardEntry::try_from(c))
@@ -51,7 +47,8 @@ pub fn delete_all_entries(conn: &Connection) -> Result<()> {
     vacuum(conn)
 }
 
-/// Perform a `VACUUM` on the DB, reducing its size by clearing deleted entries and defragmenting.
+/// Perform a `VACUUM` on the DB, reducing its size by clearing deleted entries
+/// and defragmenting.
 #[tracing::instrument(skip(conn))]
 fn vacuum(conn: &Connection) -> Result<()> {
     tracing::debug!("vacuuming DB");
@@ -179,7 +176,17 @@ pub fn delete_entry_by_position(conn: &Connection, index: usize) -> Result<()> {
 }
 
 #[tracing::instrument(skip_all)]
-pub fn upsert_entry(conn: &Connection, content: &[u8]) -> Result<()> {
+pub fn upsert_entry(conn: &Connection, entry: impl AsRef<ClipboardEntry>) -> Result<()> {
+    let ClipboardEntry {
+        content,
+        mimetype,
+        extra_preview_data,
+        content_type,
+        ..
+    } = entry.as_ref();
+    let content_type =
+        content_type.expect("should not be storing an entry with an unset content type") as u8;
+
     tracing::debug!("creating entry");
     tracing::debug!(
         "entry content preview: {}",
@@ -191,7 +198,13 @@ pub fn upsert_entry(conn: &Connection, content: &[u8]) -> Result<()> {
 
     conn.execute(
         include_str!("./upsert_post.sql"),
-        params![content, timestamp],
+        params![
+            timestamp,
+            content,
+            content_type,
+            mimetype,
+            extra_preview_data
+        ],
     )
     .map(|_| ())
     .into_diagnostic()

--- a/src/database/queries/upsert_post.sql
+++ b/src/database/queries/upsert_post.sql
@@ -1,4 +1,9 @@
 INSERT
-INTO clipboard (content, last_updated)
-VALUES (?, ?)
-ON CONFLICT (content) DO UPDATE SET last_updated = excluded.last_updated
+INTO clipboard (
+    last_updated, content, content_type, mimetype, extra_preview_data
+)
+VALUES (?, ?, ?, ?, ?)
+ON CONFLICT (content) DO UPDATE SET last_updated = excluded.last_updated,
+mimetype = excluded.mimetype,
+extra_preview_data = excluded.extra_preview_data,
+content_type = excluded.content_type

--- a/src/database/snapshots/clipvault__database__tests__migrations.snap
+++ b/src/database/snapshots/clipvault__database__tests__migrations.snap
@@ -29,6 +29,18 @@ LazyLock(
                     "02-last-updated-index",
                 ),
             },
+            M {
+                up: "ALTER TABLE clipboard ADD COLUMN content_type INTEGER;\nALTER TABLE clipboard ADD COLUMN mimetype TEXT;\nALTER TABLE clipboard ADD COLUMN extra_preview_data TEXT;\n",
+                up_hook: None,
+                down: Some(
+                    "ALTER TABLE clipboard DROP COLUMN content_type;\nALTER TABLE clipboard DROP COLUMN mimetype;\nALTER TABLE clipboard DROP COLUMN extra_preview_data;\n",
+                ),
+                down_hook: None,
+                foreign_key_check: false,
+                comment: Some(
+                    "03-preview-data",
+                ),
+            },
         ],
     },
 )

--- a/src/defaults.rs
+++ b/src/defaults.rs
@@ -1,5 +1,6 @@
-use dirs::{config_dir, data_local_dir};
 use std::{path::PathBuf, sync::LazyLock};
+
+use dirs::{config_dir, data_local_dir};
 
 pub static DB_PATH: LazyLock<PathBuf> = LazyLock::new(|| {
     data_local_dir()

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,5 @@
 use clap::Parser;
-
-use clipvault::{
-    cli::{Cli, Commands},
-    commands,
-    logging::{init_logging, trace_err},
-};
-
+use clipvault::{cli::{Cli, Commands}, commands, logging::{init_logging, trace_err}};
 use miette::{Context, IntoDiagnostic, Result};
 
 fn main() -> Result<()> {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,8 +1,7 @@
-use std::{
-    borrow::Cow,
-    time::{SystemTime, UNIX_EPOCH},
-};
+use std::{io::Cursor, time::{SystemTime, UNIX_EPOCH}};
 
+use image::{DynamicImage, ImageReader};
+use mime_sniffer::MimeTypeSniffer;
 use unicode_segmentation::UnicodeSegmentation;
 
 /// Returns the given number of bytes as a human-readable string representation.
@@ -26,19 +25,22 @@ pub fn human_bytes(mut bytes: usize) -> String {
 
 /// Truncates a string to the given number of characters.
 #[must_use]
-pub fn truncate(s: &str, max_graphemes: usize) -> Cow<'_, str> {
+pub fn truncate(mut s: String, max_graphemes: usize) -> String {
+    if max_graphemes == 0 {
+        s.clear();
+        return s;
+    } else if max_graphemes == 1 {
+        s.drain(1..);
+        return s;
+    };
+
     let graphemes = s.graphemes(true).collect::<Vec<_>>();
-
     if graphemes.is_empty() || max_graphemes >= graphemes.len() {
-        return Cow::from(s);
-    }
-
-    if max_graphemes <= 1 {
-        return graphemes[..max_graphemes].join("").into();
+        return s;
     }
 
     let max = max_graphemes - 1;
-    Cow::Owned(format!("{}…", graphemes[..max].join("")))
+    graphemes.into_iter().take(max).chain(["…"]).collect()
 }
 
 /// Current Unix timestamp in seconds - based on system time.
@@ -60,6 +62,25 @@ pub fn ignore_broken_pipe(res: std::io::Result<()>) -> std::io::Result<()> {
     }
 }
 
+/// Attempt to parse image data from a byte slice.
+///
+/// Returns a tuple in the format `(mimetype, dynamic_image)`.
+#[must_use]
+pub fn decode_image(data: &[u8]) -> Option<(&'static str, DynamicImage)> {
+    let img_reader = ImageReader::new(Cursor::new(data))
+        .with_guessed_format()
+        .ok()?;
+    let mimetype = img_reader.format()?.to_mime_type();
+    let img = img_reader.decode().ok()?;
+
+    Some((mimetype, img))
+}
+
+/// Guess the mimetype of data contained in a byte slice using `mime_sniffer`.
+pub fn get_mimetype(data: &[u8]) -> Option<String> {
+    data.sniff_mime_type().map(String::from)
+}
+
 #[cfg(test)]
 mod test {
     use miette::miette;
@@ -70,39 +91,41 @@ mod test {
     #[test]
     fn test_truncate() {
         // Character count only for basic Latin text - should be equivalent
-        assert_eq!(truncate("abc", 0).chars().count(), 0);
-        assert_eq!(truncate("", 17).chars().count(), 0);
-        assert_eq!(truncate(";lakdf", 1).chars().count(), 1);
-        assert_eq!(truncate("ioiek", 2).chars().count(), 2);
-        assert_eq!(truncate("zcxvsd", 3).chars().count(), 3);
-        assert_eq!(truncate("/.l", 5).chars().count(), 3);
+        assert_eq!(truncate("abc".into(), 0).chars().count(), 0);
+        assert_eq!(truncate("".into(), 17).chars().count(), 0);
+        assert_eq!(truncate("d".into(), 1).chars().count(), 1);
+        assert_eq!(truncate(";lakdf".into(), 1).chars().count(), 1);
+        assert_eq!(truncate("ioiek".into(), 2).chars().count(), 2);
+        assert_eq!(truncate("zcxvsd".into(), 3).chars().count(), 3);
+        assert_eq!(truncate("/.l".into(), 5).chars().count(), 3);
         assert_eq!(
-            truncate("alksdfaksldfklaslkfasfkskladfalk", 7)
+            truncate("alksdfaksldfklaslkfasfkskladfalk".into(), 7)
                 .chars()
                 .count(),
             7
         );
         assert_eq!(
-            truncate("alksdfaksldfklaslkfasfkskladfalklsdkfks", 18)
+            truncate("alksdfaksldfklaslkfasfkskladfalklsdkfks".into(), 18)
                 .chars()
                 .count(),
             18
         );
+        assert_eq!(truncate("o".into(), 1), "o");
 
         // Graphemes
-        assert_eq!(truncate("😀😀", 5).graphemes(true).count(), 2);
-        assert_eq!(truncate("😀🫡😀", 2).graphemes(true).count(), 2);
-        assert_eq!(truncate("ᚅ ᚆ ᚇ", 4).graphemes(true).count(), 4);
+        assert_eq!(truncate("😀😀".into(), 5).graphemes(true).count(), 2);
+        assert_eq!(truncate("😀🫡😀".into(), 2).graphemes(true).count(), 2);
+        assert_eq!(truncate("ᚅ ᚆ ᚇ".into(), 4).graphemes(true).count(), 4);
 
-        assert_eq!(truncate("ƀ Ɓ Ƃ ƃ Ƅ ƅ Ɔ Ƈ ƈ Ɖ Ɗ Ƌ ƌ", 4), "ƀ Ɓ…");
-        assert_eq!(truncate("й к л м н о п р с т у ф", 8), "й к л м…");
-        assert_eq!(truncate("ڠ ڡ ڢ ڣ ڤ ڥ ڦ ڧ ڨ", 16), "ڠ ڡ ڢ ڣ ڤ ڥ ڦ ڧ…");
-        assert_eq!(truncate("ᛦ ᛧ ᛨ ᛩ ᛪ ᛫ ᛬ ᛭ ᛮ ᛯ ᛰ ", 6), "ᛦ ᛧ ᛨ…");
-        assert_eq!(truncate("ᚅ ᚆ ᚇ", 5), "ᚅ ᚆ ᚇ");
-        assert_eq!(truncate("ㄱ ㄲ ㄳ ㄴ ㄵ ㄶ ㄷ ㄸ ㄹ", 4), "ㄱ ㄲ…");
-        assert_eq!(truncate("ポ マ ミ ム", 6), "ポ マ ミ…");
-        assert_eq!(truncate("🫰🫰🏿🫰🏻🫰🏽🫰🏼🫰🏾", 6), "🫰🫰🏿🫰🏻🫰🏽🫰🏼🫰🏾");
-        assert_eq!(truncate("👍👍🏾👍🏼👍🏿👍🏽👍🏻", 5), "👍👍🏾👍🏼👍🏿…");
+        assert_eq!(truncate("ƀ Ɓ Ƃ ƃ Ƅ ƅ Ɔ Ƈ ƈ Ɖ Ɗ Ƌ ƌ".into(), 4), "ƀ Ɓ…");
+        assert_eq!(truncate("й к л м н о п р с т у ф".into(), 8), "й к л м…");
+        assert_eq!(truncate("ڠ ڡ ڢ ڣ ڤ ڥ ڦ ڧ ڨ".into(), 16), "ڠ ڡ ڢ ڣ ڤ ڥ ڦ ڧ…");
+        assert_eq!(truncate("ᛦ ᛧ ᛨ ᛩ ᛪ ᛫ ᛬ ᛭ ᛮ ᛯ ᛰ ".into(), 6), "ᛦ ᛧ ᛨ…");
+        assert_eq!(truncate("ᚅ ᚆ ᚇ".into(), 5), "ᚅ ᚆ ᚇ");
+        assert_eq!(truncate("ㄱ ㄲ ㄳ ㄴ ㄵ ㄶ ㄷ ㄸ ㄹ".into(), 4), "ㄱ ㄲ…");
+        assert_eq!(truncate("ポ マ ミ ム".into(), 6), "ポ マ ミ…");
+        assert_eq!(truncate("🫰🫰🏿🫰🏻🫰🏽🫰🏼🫰🏾".into(), 6), "🫰🫰🏿🫰🏻🫰🏽🫰🏼🫰🏾");
+        assert_eq!(truncate("👍👍🏾👍🏼👍🏿👍🏽👍🏻".into(), 5), "👍👍🏾👍🏼👍🏿…");
     }
 
     #[test]

--- a/tests/cmd.rs
+++ b/tests/cmd.rs
@@ -1,15 +1,9 @@
 use std::{io::BufRead, os::unix::fs::MetadataExt, sync::LazyLock, time::Duration};
 
 use assert_cmd::{Command, cargo_bin};
-use base64::{
-    Engine, alphabet,
-    engine::{self, GeneralPurposeConfig},
-};
-use clipvault::database::init_db;
-use predicates::{
-    prelude::PredicateBooleanExt,
-    str::{contains, is_empty},
-};
+use base64::{Engine, alphabet, engine::{self, GeneralPurposeConfig}};
+use clipvault::{database::init_db, utils::human_bytes};
+use predicates::{prelude::PredicateBooleanExt, str::{contains, is_empty}};
 use proptest::prelude::*;
 use tempfile::NamedTempFile;
 
@@ -18,7 +12,8 @@ fn get_db() -> NamedTempFile {
     NamedTempFile::new().expect("couldn't create tempfile")
 }
 
-/// Builds the command to be run, pointing at the given temporary file for the database.
+/// Builds the command to be run, pointing at the given temporary file for the
+/// database.
 fn get_cmd(db: &NamedTempFile) -> Command {
     let mut cmd = Command::new(cargo_bin!());
     cmd.args(["--database", &db.path().to_string_lossy()]);
@@ -32,7 +27,7 @@ const ENCODED_BINARY: &[(&str, &[u8])] = &[
     ),
     (
         "image/jpeg",
-        b"/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k=",
+        b"/9j/2wBDAP//////////////////////////////////////////////////////////////////////////////////////wAALCAABAAEBAREA/8QAFAABAAAAAAAAAAAAAAAAAAAAA//EABQQAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQEAAD8AN//Z",
     ),
     (
         "image/bmp",
@@ -53,6 +48,22 @@ const ENCODED_BINARY: &[(&str, &[u8])] = &[
     (
         "image/tiff",
         b"SUkqAAoAAACAAA0AAAEDAAEAAAABAAAAAQEDAAEAAAABAAAAAgEDAAEAAAABAAAAAwEDAAEAAAABAAAABgEDAAEAAAABAAAACgEDAAEAAAABAAAAEQEEAAEAAAAIAAAAEgEDAAEAAAABAAAAFQEDAAEAAAABAAAAFgEDAAEAAAABAAAAFwEEAAEAAAABAAAAHAEDAAEAAAABAAAAKQEDAAIAAAAAAAEAAAAAAA==",
+    ),
+    (
+        "video/mp4",
+        b"AAAAIGZ0eXBpc29tAAACAGlzb21pc28yYXZjMW1wNDEAAAAIZnJlZQAAAAhtZGF0AAAA1m1vb3YAAABsbXZoZAAAAAAAAAAAAAAAAAAAA+gAAAAAAAEAAAEAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAABidWR0YQAAAFptZXRhAAAAAAAAACFoZGxyAAAAAAAAAABtZGlyYXBwbAAAAAAAAAAAAAAAAC1pbHN0AAAAJal0b28AAAAdZGF0YQAAAAEAAAAATGF2ZjU3LjQxLjEwMA==",
+    ),
+    (
+        "application/pdf",
+        b"JVBERi0yLjAKMSAwIG9iajw8L1R5cGUvQ2F0YWxvZy9QYWdlcyAyIDAgUj4+ZW5kb2JqCjIgMCBvYmo8PC9UeXBlL1BhZ2VzL0tpZHNbMyAwIFJdL0NvdW50IDE+PmVuZG9iagozIDAgb2JqPDwvVHlwZS9QYWdlL1BhcmVudCAyIDAgUi9SZXNvdXJjZXM8PD4+L01lZGlhQm94WzAgMCA5IDldPj5lbmRvYmoKeHJlZgowIDQKMDAwMDAwMDAwMCA2NTUzNSBmIAowMDAwMDAwMDA5IDAwMDAwIG4gCjAwMDAwMDAwNTIgMDAwMDAgbiAKMDAwMDAwMDEwMSAwMDAwMCBuIAp0cmFpbGVyPDwvUm9vdCAxIDAgUi9TaXplIDQvSURbKDEyMzQ1Njc4OTAxMjM0NTYpKDEyMzQ1Njc4OTAxMjM0NTYpXT4+CnN0YXJ0eHJlZgoxNzQKJSVFT0Y=",
+    ),
+    (
+        "application/x-rar-compressed",
+        b"UmFyIRoHAM+QcwAADQAAAAAAAAA/HnQAgCEAAAAAAAAAAAAAAAAAAAdjZk0PMwEAIAAAAG4=",
+    ),
+    (
+        "application/x-gzip",
+        b"H4sICK6G4VsCA24AAwAAAAAAAAAAAA==",
     ),
 ];
 
@@ -80,16 +91,27 @@ fn test_store_basic() {
 
     for (mime, encoded) in ENCODED_BINARY {
         let bytes = decoder.decode(encoded).unwrap();
+        let count = human_bytes(bytes.len());
+
         get_cmd(db)
             .arg("store")
             .write_stdin(bytes)
             .assert()
             .success();
-        get_cmd(db)
-            .arg("list")
-            .assert()
-            .success()
-            .stdout(contains(*mime));
+
+        if mime.starts_with("image") {
+            get_cmd(db)
+                .arg("list")
+                .assert()
+                .success()
+                .stdout(contains(format!("[[ binary data {count} {mime} 1x1 ]]",)));
+        } else {
+            get_cmd(db)
+                .arg("list")
+                .assert()
+                .success()
+                .stdout(contains(format!("[[ binary data {count} {mime} ]]")));
+        }
     }
 }
 
@@ -367,7 +389,8 @@ fn test_db_shrinks() {
         for i in 0..500 {
             get_cmd(db)
                 .arg("store")
-                // Store enough random data to make the DB grow past the initial size and exceed the VACUUM limit
+                // Store enough random data to make the DB grow past the initial size and exceed the
+                // VACUUM limit
                 .write_stdin("random_data".repeat(i))
                 .assert()
                 .success();
@@ -436,7 +459,8 @@ fn test_db_shrinks() {
 }
 
 // PROP TESTS
-/// Re-use DB for prop tests as it is not necessary for each one to have its own.
+/// Re-use DB for prop tests as it is not necessary for each one to have its
+/// own.
 static PROPTEST_DB: LazyLock<NamedTempFile> = LazyLock::new(|| {
     let db = get_db();
     // Solves sporadic failures due to locked DB


### PR DESCRIPTION
Started off just looking to fix the spacing issue on the binary previews, but ended up doing some more (see commits).

Most notably:

- Fix binary data preview
- Show byte count for all binary data types (including images)
- Fix inaccurate binary data previews by storing preview data in the DB, since otherwise the full binary blob would always need to be fetched
- Attempt to improve list performance with multi-threading (YMMV)