### PR TITLE
feat: ignore entries based on the currently focused window

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,6 +409,8 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "unicode-segmentation",
+ "wayrs-client",
+ "wayrs-protocols",
 ]
 
 [[package]]
@@ -1688,6 +1690,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2541,6 +2552,54 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "wayrs-client"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce7a46942472add8b391a170bbec77bdab6f7deb93e46da388b285f9c8f7fc7e"
+dependencies = [
+ "wayrs-core",
+ "wayrs-scanner",
+]
+
+[[package]]
+name = "wayrs-core"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "015f4f9bd84931309d0c55437de7e436719f291ef44d828c078f39ca5cd6675d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "wayrs-proto-parser"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41679c033d8ad15f8d9bbb73e50bb4ded3d4b12b8ba2123e5c526ed809b2e43c"
+dependencies = [
+ "quick-xml",
+]
+
+[[package]]
+name = "wayrs-protocols"
+version = "0.14.11+1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28e7bc60d2bcad468fc6ee5864b54b57989bba29674e25164dca77fca1382884"
+dependencies = [
+ "wayrs-client",
+]
+
+[[package]]
+name = "wayrs-scanner"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b2f7c560a8d7cbca6af14443be51fb386acd02a558724c85dac8c7bf368d28"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "wayrs-proto-parser",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,11 @@ mime-sniffer = "0.1"
 content_inspector = "0.2"
 
 # Database
-rusqlite = { version = "0.38", features = ["bundled", "extra_check", "fallible_uint"] }
+rusqlite = { version = "0.38", features = [
+  "bundled",
+  "extra_check",
+  "fallible_uint",
+] }
 rusqlite_migration = { version = "2.3", features = ["from-directory"] }
 include_dir = { version = "0.7" }
 
@@ -33,6 +37,12 @@ include_dir = { version = "0.7" }
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-appender = { version = "0.2" }
+
+# Wayland
+wayrs-client = { version = "1.3" }
+wayrs-protocols = { version = "0.14", features = [
+  "wlr-foreign-toplevel-management-unstable-v1",
+] }
 
 # Misc
 unicode-segmentation = { version = "1.13" }        # Limit preview width by grapheme clusters

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ In addition:
 - **Entry size limits**: configurable minimum and maximum size for stored entries
 - **Entry age limit:** configurable max age for entries - automatically remove old clipboard entries
 - **Ignore entries:** avoid storing certain text data using regex patterns, e.g. `^<meta http-equiv=`
+- **Ignore windows:** avoid storing data from specific windows using regex patterns, e.g. `.*Pass.*`
 - **Informative previews:** previews for binary data support many more types, e.g. `video/mp4`, `application/pdf`, etc.
 
 ## Requirements

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -91,6 +91,27 @@ pub struct StoreArgs {
     /// features.
     #[arg(long, env = "CLIPVAULT_IGNORE_PATTERN")]
     pub ignore_pattern: Option<Vec<Regex>>,
+
+    /// If the title or ID of the currently focused Wayland toplevel (window)
+    /// matches any of the given regex patterns, entries will not be stored.
+    ///
+    /// This will only work on a Wayland compositor with support for wlr
+    /// foreign toplevel management e.g. Sway, Niri, Wayfire, Hyprland, etc.
+    /// You can check for compositor support at
+    /// https://wayland.app/protocols/wlr-foreign-toplevel-management-unstable-v1#compositor-support
+    ///
+    /// To specify multiple patterns, simply call the argument again with a new
+    /// pattern. Be mindful of the fact that every regex pattern given will
+    /// be tested against every text input.
+    ///
+    /// e.g. clipvault --store --window-ignore-pattern '.*[pP]ass.*'
+    /// --window-ignore-pattern '^Bitwarden'
+    ///
+    /// Note that look-around and backreferences are not supported, as the Rust
+    /// implementation of a regex engine used does not support those
+    /// features.
+    #[arg(long, env = "CLIPVAULT_WINDOW_IGNORE_PATTERN")]
+    pub window_ignore_pattern: Option<Vec<Regex>>,
 }
 
 impl Default for StoreArgs {
@@ -103,6 +124,7 @@ impl Default for StoreArgs {
             min_entry_length: defaults::MIN_ENTRY_LEN,
             store_sensitive: false,
             ignore_pattern: None,
+            window_ignore_pattern: None,
         }
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -89,7 +89,7 @@ pub struct StoreArgs {
     /// Note that look-around and backreferences are not supported, as the Rust
     /// implementation of a regex engine used does not support those
     /// features.
-    #[arg(long, action, env = "CLIPVAULT_IGNORE_PATTERN", num_args = 1)]
+    #[arg(long, env = "CLIPVAULT_IGNORE_PATTERN")]
     pub ignore_pattern: Option<Vec<Regex>>,
 }
 

--- a/src/commands/store.rs
+++ b/src/commands/store.rs
@@ -5,9 +5,9 @@ use image::GenericImageView;
 use miette::{Context, IntoDiagnostic, Result, bail};
 use tracing::instrument;
 
-use crate::{cli::StoreArgs, database::{data::ClipboardEntry, init_db, queries::{delete_all_entries, delete_entries_older_than, trim_entries, upsert_entry}}, utils::{decode_image, get_mimetype, now}};
+use crate::{cli::StoreArgs, database::{data::ClipboardEntry, init_db, queries::{delete_all_entries, delete_entries_older_than, trim_entries, upsert_entry}}, utils::{decode_image, get_mimetype, now}, wayland::wlr_toplevel::get_active_toplevel};
 
-#[instrument]
+#[instrument(skip(path_db, args))]
 pub fn execute(path_db: &Path, args: StoreArgs) -> Result<()> {
     execute_with_source(path_db, args, stdin())
 }
@@ -22,6 +22,7 @@ pub fn execute_with_source(path_db: &Path, args: StoreArgs, mut source: impl Rea
         min_entry_length: min_bytes,
         store_sensitive,
         ignore_pattern,
+        window_ignore_pattern,
     } = args;
 
     // Min conflicts with max
@@ -85,8 +86,9 @@ pub fn execute_with_source(path_db: &Path, args: StoreArgs, mut source: impl Rea
         return Ok(());
     }
 
-    // Check user-provided ignore pattern
+    // Check user-provided ignore patterns
     if let Some(regexes) = ignore_pattern
+        && !regexes.is_empty()
         && matches!(
             content_inspector::inspect(&buf),
             ContentType::UTF_8 | ContentType::UTF_8_BOM
@@ -97,6 +99,33 @@ pub fn execute_with_source(path_db: &Path, args: StoreArgs, mut source: impl Rea
     {
         tracing::debug!("content matched an ignore pattern");
         return Ok(());
+    }
+
+    // Check user-provided window ignore patterns
+    if let Some(regexes) = window_ignore_pattern
+        && !regexes.is_empty()
+    {
+        match get_active_toplevel() {
+            Ok(Some(active_top_window)) => {
+                let title = active_top_window
+                    .title
+                    .unwrap_or_else(|| String::from("[untitled]"));
+                let app_id = active_top_window
+                    .app_id
+                    .unwrap_or_else(|| String::from("[unknown]"));
+                let haystack = format!("{app_id}: {title}");
+
+                tracing::debug!("focused window: ({haystack})");
+                if regexes.iter().any(|re| re.is_match(&haystack)) {
+                    tracing::debug!("Focused window ({haystack}) matched an ignore pattern");
+                    return Ok(());
+                } else {
+                    tracing::trace!("Focused window ({haystack}) did not match any ignore pattern");
+                }
+            }
+            Ok(None) => tracing::warn!("No focused window found"),
+            Err(e) => tracing::error!("Failed to get the active toplevel: {e}"),
+        }
     }
 
     // Only get DB connection after parsing STDIN - avoid locking

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,3 +4,4 @@ pub mod database;
 pub mod defaults;
 pub mod logging;
 pub mod utils;
+pub mod wayland;

--- a/src/wayland/mod.rs
+++ b/src/wayland/mod.rs
@@ -1,0 +1,1 @@
+pub mod wlr_toplevel;

--- a/src/wayland/wlr_toplevel.rs
+++ b/src/wayland/wlr_toplevel.rs
@@ -1,0 +1,108 @@
+// Reference implementation, thanks to the author:
+// https://github.com/greshake/i3status-rust/blob/master/src/blocks/focused_window/wlr_toplevel_management.rs
+
+use std::collections::HashMap;
+
+use miette::{Context, IntoDiagnostic, Result};
+use wayrs_client::{Connection, EventCtx};
+use wayrs_protocols::wlr_foreign_toplevel_management_unstable_v1::{ZwlrForeignToplevelHandleV1, ZwlrForeignToplevelManagerV1, zwlr_foreign_toplevel_handle_v1, zwlr_foreign_toplevel_manager_v1};
+
+#[derive(Default)]
+struct ToplevelState {
+    toplevels: HashMap<ZwlrForeignToplevelHandleV1, ToplevelInfo>,
+    active_toplevel: Option<ZwlrForeignToplevelHandleV1>,
+}
+
+#[derive(Default, Clone)]
+pub struct ToplevelInfo {
+    pub title: Option<String>,
+    pub app_id: Option<String>,
+    pub is_focused: bool,
+}
+
+fn handle_manager_events(ctx: EventCtx<ToplevelState, ZwlrForeignToplevelManagerV1>) {
+    use zwlr_foreign_toplevel_manager_v1::Event::*;
+    match ctx.event {
+        Toplevel(handle) => {
+            ctx.state.toplevels.insert(handle, ToplevelInfo::default());
+            ctx.conn.set_callback_for(handle, handle_toplevel_events);
+        }
+        Finished => {
+            tracing::error!("Unexpected 'finished' event");
+            ctx.conn.break_dispatch_loop();
+        }
+        _ => {}
+    }
+}
+
+fn handle_toplevel_events(ctx: EventCtx<ToplevelState, ZwlrForeignToplevelHandleV1>) {
+    use zwlr_foreign_toplevel_handle_v1::Event::*;
+
+    let Some(toplevel) = ctx.state.toplevels.get_mut(&ctx.proxy) else {
+        return;
+    };
+
+    match ctx.event {
+        Title(title) => {
+            toplevel.title = Some(String::from_utf8_lossy(title.as_bytes()).into_owned());
+        }
+        AppId(app_id) => {
+            toplevel.app_id = Some(String::from_utf8_lossy(app_id.as_bytes()).into_owned())
+        }
+        // State flags are given as an array of packed u32 values. We loop over these
+        // values (by grouping 4 u8 values) and try to find the Activated state (2).
+        State(state_bytes) => {
+            toplevel.is_focused = state_bytes
+                .chunks_exact(4)
+                .map(|b| u32::from_ne_bytes(b.try_into().expect("slice somehow not 4 bytes long")))
+                .any(|s| s == zwlr_foreign_toplevel_handle_v1::State::Activated as u32);
+        }
+        Closed => {
+            if ctx.state.active_toplevel == Some(ctx.proxy) {
+                ctx.state.active_toplevel = None;
+            }
+
+            ctx.proxy.destroy(ctx.conn);
+            ctx.state.toplevels.remove(&ctx.proxy);
+        }
+        Done => {
+            if toplevel.is_focused {
+                ctx.state.active_toplevel = Some(ctx.proxy);
+            } else if ctx.state.active_toplevel == Some(ctx.proxy) {
+                ctx.state.active_toplevel = None;
+            }
+        }
+        _ => {}
+    }
+}
+
+fn get_toplevels() -> Result<ToplevelState> {
+    let mut conn = Connection::<ToplevelState>::connect().unwrap();
+    // Setup globals
+    conn.blocking_roundtrip()
+        .into_diagnostic()
+        .context("first round trip failed")?;
+
+    let _manager: ZwlrForeignToplevelManagerV1 = conn
+        .bind_singleton_with_cb(1..=3, handle_manager_events)
+        .into_diagnostic()
+        .context("compositor does not support wlr-foreign-toplevel-management-unstable-v1")
+        .unwrap();
+
+    let mut state = ToplevelState::default();
+
+    conn.blocking_roundtrip()
+        .into_diagnostic()
+        .context("second round trip failed")?;
+    conn.dispatch_events(&mut state);
+
+    Ok(state)
+}
+
+pub fn get_active_toplevel() -> Result<Option<ToplevelInfo>> {
+    let mut state = get_toplevels()?;
+    let active_toplevel = state
+        .active_toplevel
+        .and_then(|k| state.toplevels.remove_entry(&k).map(|(_, v)| v));
+    Ok(active_toplevel)
+}


### PR DESCRIPTION

This functionality is only implemented for Wayland compositors which support the wlr foreign toplevel management protocol, but will not cause a hard failure in other compositors.

See the [Wayland Explorer](https://wayland.app/protocols/wlr-foreign-toplevel-management-unstable-v1) to check compositor support.