### PR TITLE
chore: fmt imports

### DIFF
--- a/benches/base.rs
+++ b/benches/base.rs
@@ -1,6 +1,21 @@
-use std::{io::Cursor, sync::LazyLock};
+use std::{
+    io::Cursor,
+    sync::LazyLock,
+};
 
-use clipvault::{cli::{GetDelArgs, ListArgs, StoreArgs}, commands::{get, list, store}, defaults};
+use clipvault::{
+    cli::{
+        GetDelArgs,
+        ListArgs,
+        StoreArgs,
+    },
+    commands::{
+        get,
+        list,
+        store,
+    },
+    defaults,
+};
 #[cfg(feature = "bench_mem")]
 use divan::AllocProfiler;
 use tempfile::NamedTempFile;

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,7 +1,8 @@
 group_imports = "StdExternalCrate"
 imports_granularity = "Crate"
-imports_indent = "Visual"
-imports_layout = "Horizontal"
+imports_indent = "Block"
+imports_layout = "Vertical"
+reorder_imports = true
 newline_style = "Unix"
 reorder_modules = true
 style_edition = "2024"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,13 @@
-use std::{path::PathBuf, str::FromStr};
+use std::{
+    path::PathBuf,
+    str::FromStr,
+};
 
-use clap::{Parser, Subcommand, ValueHint};
+use clap::{
+    Parser,
+    Subcommand,
+    ValueHint,
+};
 use regex::Regex;
 
 use crate::defaults;

--- a/src/commands/clear.rs
+++ b/src/commands/clear.rs
@@ -2,7 +2,10 @@ use std::path::Path;
 
 use miette::Result;
 
-use crate::database::{init_db, queries::delete_all_entries};
+use crate::database::{
+    init_db,
+    queries::delete_all_entries,
+};
 
 #[tracing::instrument(skip(path_db))]
 pub fn execute(path_db: &Path) -> Result<()> {

--- a/src/commands/delete.rs
+++ b/src/commands/delete.rs
@@ -1,9 +1,33 @@
-use std::{io::{Read, stdin}, path::Path};
+use std::{
+    io::{
+        Read,
+        stdin,
+    },
+    path::Path,
+};
 
-use miette::{Context, IntoDiagnostic, Result, miette};
+use miette::{
+    Context,
+    IntoDiagnostic,
+    Result,
+    miette,
+};
 
-use super::{extract_id, wrap_index};
-use crate::{cli::GetDelArgs, database::{init_db, queries::{count_entries, delete_entry_by_id, delete_entry_by_position}}};
+use super::{
+    extract_id,
+    wrap_index,
+};
+use crate::{
+    cli::GetDelArgs,
+    database::{
+        init_db,
+        queries::{
+            count_entries,
+            delete_entry_by_id,
+            delete_entry_by_position,
+        },
+    },
+};
 
 #[tracing::instrument(skip(path_db))]
 pub fn execute(path_db: &Path, args: GetDelArgs) -> Result<()> {

--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -1,9 +1,35 @@
-use std::{io::{Read, Write, stdin, stdout}, path::Path};
+use std::{
+    io::{
+        Read,
+        Write,
+        stdin,
+        stdout,
+    },
+    path::Path,
+};
 
-use miette::{Context, IntoDiagnostic, Result, miette};
+use miette::{
+    Context,
+    IntoDiagnostic,
+    Result,
+    miette,
+};
 
 use super::extract_id;
-use crate::{cli::GetDelArgs, commands::wrap_index, database::{data::ClipboardEntry, init_db, queries::{count_entries, get_entry_by_id, get_entry_by_position}}, utils::ignore_broken_pipe};
+use crate::{
+    cli::GetDelArgs,
+    commands::wrap_index,
+    database::{
+        data::ClipboardEntry,
+        init_db,
+        queries::{
+            count_entries,
+            get_entry_by_id,
+            get_entry_by_position,
+        },
+    },
+    utils::ignore_broken_pipe,
+};
 
 fn get_entry(path_db: &Path, mut input: String) -> Result<ClipboardEntry> {
     // Read from STDIN if no argument given

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -1,11 +1,47 @@
-use std::{borrow::Cow, io::{BufWriter, Write, stdout}, num::NonZero, path::Path, sync::{Arc, atomic::{AtomicUsize, Ordering}, mpsc::sync_channel}, thread};
+use std::{
+    borrow::Cow,
+    io::{
+        BufWriter,
+        Write,
+        stdout,
+    },
+    num::NonZero,
+    path::Path,
+    sync::{
+        Arc,
+        atomic::{
+            AtomicUsize,
+            Ordering,
+        },
+        mpsc::sync_channel,
+    },
+    thread,
+};
 
 use content_inspector::ContentType;
 use image::GenericImageView;
-use miette::{Context, IntoDiagnostic, Result};
+use miette::{
+    Context,
+    IntoDiagnostic,
+    Result,
+};
 
 use super::SEPARATOR;
-use crate::{cli::ListArgs, database::{data::ClipboardEntry, init_db, queries::get_all_entries}, utils::{decode_image, get_mimetype, human_bytes, ignore_broken_pipe, truncate}};
+use crate::{
+    cli::ListArgs,
+    database::{
+        data::ClipboardEntry,
+        init_db,
+        queries::get_all_entries,
+    },
+    utils::{
+        decode_image,
+        get_mimetype,
+        human_bytes,
+        ignore_broken_pipe,
+        truncate,
+    },
+};
 
 #[tracing::instrument()]
 fn preview_text(entry: &ClipboardEntry) -> String {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -4,7 +4,11 @@ pub mod get;
 pub mod list;
 pub mod store;
 
-use miette::{Context, IntoDiagnostic, Result};
+use miette::{
+    Context,
+    IntoDiagnostic,
+    Result,
+};
 
 pub(super) const SEPARATOR: &str = "\t";
 

--- a/src/commands/store.rs
+++ b/src/commands/store.rs
@@ -1,11 +1,40 @@
-use std::{io::{Read, stdin}, path::Path};
+use std::{
+    io::{
+        Read,
+        stdin,
+    },
+    path::Path,
+};
 
 use content_inspector::ContentType;
 use image::GenericImageView;
-use miette::{Context, IntoDiagnostic, Result, bail};
+use miette::{
+    Context,
+    IntoDiagnostic,
+    Result,
+    bail,
+};
 use tracing::instrument;
 
-use crate::{cli::StoreArgs, database::{data::ClipboardEntry, init_db, queries::{delete_all_entries, delete_entries_older_than, trim_entries, upsert_entry}}, utils::{decode_image, get_mimetype, now}, wayland::wlr_toplevel::get_active_toplevel};
+use crate::{
+    cli::StoreArgs,
+    database::{
+        data::ClipboardEntry,
+        init_db,
+        queries::{
+            delete_all_entries,
+            delete_entries_older_than,
+            trim_entries,
+            upsert_entry,
+        },
+    },
+    utils::{
+        decode_image,
+        get_mimetype,
+        now,
+    },
+    wayland::wlr_toplevel::get_active_toplevel,
+};
 
 #[instrument(skip(path_db, args))]
 pub fn execute(path_db: &Path, args: StoreArgs) -> Result<()> {

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -1,7 +1,17 @@
-use std::{path::Path, sync::LazyLock};
+use std::{
+    path::Path,
+    sync::LazyLock,
+};
 
-use include_dir::{Dir, include_dir};
-use miette::{Context, IntoDiagnostic, Result};
+use include_dir::{
+    Dir,
+    include_dir,
+};
+use miette::{
+    Context,
+    IntoDiagnostic,
+    Result,
+};
 use rusqlite::Connection;
 use rusqlite_migration::Migrations;
 use tracing::instrument;

--- a/src/database/queries/mod.rs
+++ b/src/database/queries/mod.rs
@@ -1,7 +1,19 @@
-use miette::{Context, IntoDiagnostic, Result, miette};
-use rusqlite::{Connection, fallible_iterator::FallibleIterator, params};
+use miette::{
+    Context,
+    IntoDiagnostic,
+    Result,
+    miette,
+};
+use rusqlite::{
+    Connection,
+    fallible_iterator::FallibleIterator,
+    params,
+};
 
-use crate::{database::data::ClipboardEntry, utils::now};
+use crate::{
+    database::data::ClipboardEntry,
+    utils::now,
+};
 
 #[tracing::instrument(skip(conn))]
 pub fn count_entries(conn: &Connection) -> Result<usize> {

--- a/src/defaults.rs
+++ b/src/defaults.rs
@@ -1,6 +1,12 @@
-use std::{path::PathBuf, sync::LazyLock};
+use std::{
+    path::PathBuf,
+    sync::LazyLock,
+};
 
-use dirs::{config_dir, data_local_dir};
+use dirs::{
+    config_dir,
+    data_local_dir,
+};
 
 pub static DB_PATH: LazyLock<PathBuf> = LazyLock::new(|| {
     data_local_dir()

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,10 +1,23 @@
-use std::{fs::create_dir_all, path::PathBuf};
+use std::{
+    fs::create_dir_all,
+    path::PathBuf,
+};
 
 use dirs::state_dir;
-use miette::{Context, IntoDiagnostic, Result};
+use miette::{
+    Context,
+    IntoDiagnostic,
+    Result,
+};
 use tracing::level_filters::LevelFilter;
-use tracing_appender::{non_blocking::WorkerGuard, rolling::Rotation};
-use tracing_subscriber::{EnvFilter, prelude::*};
+use tracing_appender::{
+    non_blocking::WorkerGuard,
+    rolling::Rotation,
+};
+use tracing_subscriber::{
+    EnvFilter,
+    prelude::*,
+};
 
 fn get_logs_dir() -> Result<PathBuf> {
     let dir = state_dir()

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,20 @@
 use clap::Parser;
-use clipvault::{cli::{Cli, Commands}, commands, logging::{init_logging, trace_err}};
-use miette::{Context, IntoDiagnostic, Result};
+use clipvault::{
+    cli::{
+        Cli,
+        Commands,
+    },
+    commands,
+    logging::{
+        init_logging,
+        trace_err,
+    },
+};
+use miette::{
+    Context,
+    IntoDiagnostic,
+    Result,
+};
 
 fn main() -> Result<()> {
     let _guard = init_logging()?;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,15 @@
-use std::{io::Cursor, time::{SystemTime, UNIX_EPOCH}};
+use std::{
+    io::Cursor,
+    time::{
+        SystemTime,
+        UNIX_EPOCH,
+    },
+};
 
-use image::{DynamicImage, ImageReader};
+use image::{
+    DynamicImage,
+    ImageReader,
+};
 use mime_sniffer::MimeTypeSniffer;
 use unicode_segmentation::UnicodeSegmentation;
 
@@ -144,7 +153,10 @@ mod test {
 
     #[test]
     fn test_ignore_broken_pipe() {
-        use std::io::{Error, ErrorKind};
+        use std::io::{
+            Error,
+            ErrorKind,
+        };
 
         assert!(ignore_broken_pipe(Err(Error::new(ErrorKind::NotFound, miette!("")))).is_err());
         assert!(

--- a/src/wayland/wlr_toplevel.rs
+++ b/src/wayland/wlr_toplevel.rs
@@ -3,9 +3,21 @@
 
 use std::collections::HashMap;
 
-use miette::{Context, IntoDiagnostic, Result};
-use wayrs_client::{Connection, EventCtx};
-use wayrs_protocols::wlr_foreign_toplevel_management_unstable_v1::{ZwlrForeignToplevelHandleV1, ZwlrForeignToplevelManagerV1, zwlr_foreign_toplevel_handle_v1, zwlr_foreign_toplevel_manager_v1};
+use miette::{
+    Context,
+    IntoDiagnostic,
+    Result,
+};
+use wayrs_client::{
+    Connection,
+    EventCtx,
+};
+use wayrs_protocols::wlr_foreign_toplevel_management_unstable_v1::{
+    ZwlrForeignToplevelHandleV1,
+    ZwlrForeignToplevelManagerV1,
+    zwlr_foreign_toplevel_handle_v1,
+    zwlr_foreign_toplevel_manager_v1,
+};
 
 #[derive(Default)]
 struct ToplevelState {

--- a/tests/cmd.rs
+++ b/tests/cmd.rs
@@ -1,9 +1,35 @@
-use std::{io::BufRead, os::unix::fs::MetadataExt, sync::LazyLock, time::Duration};
+use std::{
+    io::BufRead,
+    os::unix::fs::MetadataExt,
+    sync::LazyLock,
+    time::Duration,
+};
 
-use assert_cmd::{Command, cargo_bin};
-use base64::{Engine, alphabet, engine::{self, GeneralPurposeConfig}};
-use clipvault::{database::init_db, utils::human_bytes};
-use predicates::{prelude::PredicateBooleanExt, str::{contains, is_empty}};
+use assert_cmd::{
+    Command,
+    cargo_bin,
+};
+use base64::{
+    Engine,
+    alphabet,
+    engine::{
+        GeneralPurposeConfig,
+        {
+            self,
+        },
+    },
+};
+use clipvault::{
+    database::init_db,
+    utils::human_bytes,
+};
+use predicates::{
+    prelude::PredicateBooleanExt,
+    str::{
+        contains,
+        is_empty,
+    },
+};
 use proptest::prelude::*;
 use tempfile::NamedTempFile;
 


### PR DESCRIPTION
Tweak some options in `rustfmt.toml` to change formatting for imports