### PR TITLE
Feature: nix flake compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+result/

--- a/README.md
+++ b/README.md
@@ -57,6 +57,33 @@ cargo install --git https://github.com/rolv-apneseth/clipvault --locked
 paru -S clipvault
 ```
 
+### Nix flakes
+
+Add clipvault to your flake inputs:
+```nix
+inputs = {
+  matugen = {
+     url = "github:Rolv-Apneseth/clipvault";
+    # If you need a specific version:
+    ref = "refs/tags/v1.3.0";
+  };
+  # ...
+};
+```
+
+Then you can add it to your packages:
+```nix
+let
+  system = "x86_64-linux";
+  # OR: system = "aarch64-linux";
+in {
+  environment.systemPackages = with pkgs; [    
+    # ...
+    inputs.clipvault.packages.${system}.default
+  ];
+}
+```
+
 ### Manual
 
 1. Download the tarball for your computer's architecture (probably `x86_64`) from the [releases page](https://github.com/Rolv-Apneseth/clipvault/releases)

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,34 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+let
+  manifest = (pkgs.lib.importTOML ./Cargo.toml).package;
+in
+pkgs.rustPlatform.buildRustPackage rec {
+  pname = manifest.name;
+  version = manifest.version;
+
+  src = pkgs.lib.cleanSource ./.;
+
+  cargoLock = {
+    lockFile = ./Cargo.lock;
+# These are the output hashes of nix packaging for vendoring git dependencies.
+# They cannot be calculated during build time.
+# They make sure that packages/dependencies are resolver reproducibly.
+# The hash needs to be adjusted with a new version of wayrs-client.
+# for debugging/ mismatches run "nix flake check --all-systems" or "nix build"
+# See https://nix.dev/manual/nix/2.34/language/advanced-attributes.html#adv-attr-outputHash
+
+    outputHashes = {
+      "wayrs-client-1.3.1" = "sha256-9LnJnuUkE3M+7dqrfX4L7HEgBNrB4sbYXN0pVhCnNl4=";
+    };
+  };
+#  WARNING: This is a hack to make the build work.
+#  It is required so the tests are working. They need a valid User home filesystem
+#  and tey will fail of executed from /nix/store
+#  It creates a build sandbox instead
+  preCheck = ''
+    export HOME="$TMPDIR/home"
+    mkdir -p "$HOME"
+  '';
+
+}

--- a/default.nix
+++ b/default.nix
@@ -24,7 +24,7 @@ pkgs.rustPlatform.buildRustPackage rec {
   };
 #  WARNING: This is a hack to make the build work.
 #  It is required so the tests are working. They need a valid User home filesystem
-#  and tey will fail of executed from /nix/store
+#  and they will fail if executed from /nix/store
 #  It creates a build sandbox instead
   preCheck = ''
     export HOME="$TMPDIR/home"

--- a/default.nix
+++ b/default.nix
@@ -24,7 +24,6 @@ pkgs.rustPlatform.buildRustPackage rec {
       "wayrs-client-1.3.1" = "sha256-9LnJnuUkE3M+7dqrfX4L7HEgBNrB4sbYXN0pVhCnNl4=";
     };
   };
-  #  WARNING: This is a hack to make the build work.
   #  It is required so the tests are working. They need a valid User home filesystem
   #  and they will fail if executed from /nix/store
   #  It creates a build sandbox instead

--- a/default.nix
+++ b/default.nix
@@ -13,7 +13,7 @@ pkgs.rustPlatform.buildRustPackage rec {
     lockFile = ./Cargo.lock;
 # These are the output hashes of nix packaging for vendoring git dependencies.
 # They cannot be calculated during build time.
-# They make sure that packages/dependencies are resolver reproducibly.
+# They make sure that packages/dependencies are resolved reproducibly.
 # The hash needs to be adjusted with a new version of wayrs-client.
 # for debugging/ mismatches run "nix flake check --all-systems" or "nix build"
 # See https://nix.dev/manual/nix/2.34/language/advanced-attributes.html#adv-attr-outputHash

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,6 @@
-{ pkgs ? import <nixpkgs> {} }:
+{
+  pkgs ? import <nixpkgs> { },
+}:
 
 let
   manifest = (pkgs.lib.importTOML ./Cargo.toml).package;
@@ -11,21 +13,21 @@ pkgs.rustPlatform.buildRustPackage rec {
 
   cargoLock = {
     lockFile = ./Cargo.lock;
-# These are the output hashes of nix packaging for vendoring git dependencies.
-# They cannot be calculated during build time.
-# They make sure that packages/dependencies are resolved reproducibly.
-# The hash needs to be adjusted with a new version of wayrs-client.
-# for debugging/ mismatches run "nix flake check --all-systems" or "nix build"
-# See https://nix.dev/manual/nix/2.34/language/advanced-attributes.html#adv-attr-outputHash
+    # These are the output hashes of nix packaging for vendoring git dependencies.
+    # They cannot be calculated during build time.
+    # They make sure that packages/dependencies are resolved reproducibly.
+    # The hash needs to be adjusted with a new version of wayrs-client.
+    # for debugging/ mismatches run "nix flake check --all-systems" or "nix build"
+    # See https://nix.dev/manual/nix/2.34/language/advanced-attributes.html#adv-attr-outputHash
 
     outputHashes = {
       "wayrs-client-1.3.1" = "sha256-9LnJnuUkE3M+7dqrfX4L7HEgBNrB4sbYXN0pVhCnNl4=";
     };
   };
-#  WARNING: This is a hack to make the build work.
-#  It is required so the tests are working. They need a valid User home filesystem
-#  and they will fail if executed from /nix/store
-#  It creates a build sandbox instead
+  #  WARNING: This is a hack to make the build work.
+  #  It is required so the tests are working. They need a valid User home filesystem
+  #  and they will fail if executed from /nix/store
+  #  It creates a build sandbox instead
   preCheck = ''
     export HOME="$TMPDIR/home"
     mkdir -p "$HOME"

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1787498568,
+        "narHash": "sha256-9i/VTdusq/+NM/tz+J1Re+ojkMB8MBf0QshnYfzHz30=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "56c02bc00adcf003215cc4bd996d6efaf4cff188",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1689347949,
+        "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
+        "owner": "nix-systems",
+        "repo": "default-linux",
+        "rev": "31732fcf5e8fea42e59c2488ad31a0e651500f68",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default-linux",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,23 @@
+{
+  description = "Clipboard history manager for Wayland";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    systems.url = "github:nix-systems/default-linux";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    systems,
+  }:
+    let
+      forAllSystems = nixpkgs.lib.genAttrs (import systems);
+      pkgsFor = nixpkgs.legacyPackages;
+    in
+    {
+      packages = forAllSystems (system: {
+        default = pkgsFor.${system}.callPackage ./. {};
+      });
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -6,18 +6,19 @@
     systems.url = "github:nix-systems/default-linux";
   };
 
-  outputs = {
-    self,
-    nixpkgs,
-    systems,
-  }:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      systems,
+    }:
     let
       forAllSystems = nixpkgs.lib.genAttrs (import systems);
       pkgsFor = nixpkgs.legacyPackages;
     in
     {
       packages = forAllSystems (system: {
-        default = pkgsFor.${system}.callPackage ./. {};
+        default = pkgsFor.${system}.callPackage ./. { };
       });
     };
 }


### PR DESCRIPTION
Added nix flake compatibility so that nix/nixOS users can easily install clipvault via flakes without having to define overlays manually.

**Changes:**
- flake.nix — Defines the Flake inputs and exposes Clipvault as the default package for supported systems.
- default.nix — Defines the Clipvault package using rustPlatform.buildRustPackage and the existing Cargo.lock.
- flake.lock — Pins the Flake inputs for reproducible builds.
- README.md — Adds instructions for using Clipvault through Nix Flakes.
Test environment — Sets a writable $HOME during the Nix build so the existing test suite can run inside the Nix sandbox.

**Testing:**
Verified that Clipvault can be:

- Built with nix build
- Checked with nix flake check
- Run with nix run
- Temporarily installed with nix shell
- Consumed as a Flake input from GitHub