### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ paru -S clipvault
 Add clipvault to your flake inputs:
 ```nix
 inputs = {
-  matugen = {
+  clipvault = {
      url = "github:Rolv-Apneseth/clipvault";
     # If you need a specific version:
     ref = "refs/tags/v1.3.0";


### PR DESCRIPTION
Fixed typo in the installation instructions in README.md.
The input was defined as matugen and I changed it to clipvault.